### PR TITLE
fix:concurrent database updates

### DIFF
--- a/internal/counter/domain/order.go
+++ b/internal/counter/domain/order.go
@@ -123,6 +123,7 @@ func (o *Order) Apply(event *events.OrderUp) error {
 	}
 
 	o.LineItems[index].ItemStatus = shared.StatusFulfilled
+	o.LineItems = []*LineItem{o.LineItems[index]}
 
 	if checkFulfilledStatus(o.LineItems) {
 		o.OrderStatus = shared.StatusFulfilled


### PR DESCRIPTION
Multiple consumption processes(workerPoolSize) query and update at the same time, which may cause("order"."line_items") item_status to change from 2 to 1